### PR TITLE
Allow install_path to be passed via env var

### DIFF
--- a/openie/openie.py
+++ b/openie/openie.py
@@ -17,7 +17,8 @@ class StanfordOpenIE:
             *args, **kwargs
     ):
         if install_dir_path is None:
-            self.install_dir = Path('~/.stanfordnlp_resources/').expanduser()
+            default_path = Path('~/.stanfordnlp_resources/').expanduser()
+            self.install_dir = os.environ.get("OPENIE_INSTALL_PATH", default_path)
         else:
             self.install_dir = Path(install_dir_path)
         self.install_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
Sometimes, it would be nice to override the default install path with an environment variable. This diff accomplishes that.